### PR TITLE
Add the normal/pathogenic limits for each variant to the VCF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [x.x.x]
+Add normal and pathologic limits for each variant to the VCF
+
 ## [0.5.4]
 Update Manifest to include json resource file.
 

--- a/stranger/cli.py
+++ b/stranger/cli.py
@@ -51,11 +51,27 @@ def cli(context, vcf, repeats_file, loglevel):
         LOG.warning("Could not find any repeat info")
         context.abort()
 
-    stranger_info = 'STR_STATUS'
-    stranger_description = "Repeat expansion status. Alternatives in [normal, pre_mutation, full_mutation]"
-    stranger_header = '##INFO=<ID={0},Number={1},Type={2},Description="{3}">'.format(
-        stranger_info, 'A', 'String', stranger_description
-    )
+    header_definitions = [
+        {
+            'id': 'STR_STATUS', 'num': 'A', 'type': 'String',
+            'desc': 'Repeat expansion status. Alternatives in [normal, pre_mutation, full_mutation]'
+        },
+        {
+            'id': 'STR_NORMAL_MAX', 'num': '1', 'type': 'Integer',
+            'desc': 'Max number of repeats allowed to call as normal'
+        },
+        {
+            'id': 'STR_FULLMUT_MIN', 'num': '1', 'type': 'Integer',
+            'desc': 'Min number of repeats required to call as full mutation'
+        }
+    ]
+
+    stranger_headers = []
+    for hdef in header_definitions:
+        header = '##INFO=<ID={0},Number={1},Type={2},Description="{3}">'.format(
+            hdef.get('id'), hdef.get('num'), hdef.get('type'), hdef.get('desc'))
+        stranger_headers.append(header)
+            
 
     if vcf.endswith('.gz'):
         LOG.info("Vcf is zipped")
@@ -70,8 +86,9 @@ def cli(context, vcf, repeats_file, loglevel):
             if line.startswith('##'):
                 click.echo(line)
                 continue
-            # Print the new header line describing stranger annotation
-            click.echo(stranger_header)
+            # Print the new header lines describing stranger annotation
+            for header in stranger_headers:
+                click.echo(header)
             # Print the vcf header line
             header_info = line[1:].split('\t')
             click.echo(line)
@@ -79,8 +96,10 @@ def cli(context, vcf, repeats_file, loglevel):
         variant_info = dict(zip(header_info, line.split('\t')))
         variant_info['alts'] = variant_info['ALT'].split(',')
         variant_info['info_dict'] = get_info_dict(variant_info['INFO'])
-        repeat_string = get_repeat_info(variant_info, repeat_information)
-        if repeat_string:
-            variant_info['info_dict'][stranger_info] = repeat_string
+        repeat_data = get_repeat_info(variant_info, repeat_information)
+        if repeat_data:
+            variant_info['info_dict']['STR_STATUS'] = repeat_data['repeat_strings']
+            variant_info['info_dict']['STR_NORMAL_MAX'] = str(repeat_data['lower'])
+            variant_info['info_dict']['STR_FULLMUT_MIN'] = str(repeat_data['upper'])
 
         click.echo(get_variant_line(variant_info, header_info))

--- a/stranger/cli.py
+++ b/stranger/cli.py
@@ -61,8 +61,8 @@ def cli(context, vcf, repeats_file, loglevel):
             'desc': 'Max number of repeats allowed to call as normal'
         },
         {
-            'id': 'STR_FULLMUT_MIN', 'num': '1', 'type': 'Integer',
-            'desc': 'Min number of repeats required to call as full mutation'
+            'id': 'STR_PATHOLOGIC_MIN', 'num': '1', 'type': 'Integer',
+            'desc': 'Min number of repeats required to call as pathologic'
         }
     ]
 
@@ -100,6 +100,6 @@ def cli(context, vcf, repeats_file, loglevel):
         if repeat_data:
             variant_info['info_dict']['STR_STATUS'] = repeat_data['repeat_strings']
             variant_info['info_dict']['STR_NORMAL_MAX'] = str(repeat_data['lower'])
-            variant_info['info_dict']['STR_FULLMUT_MIN'] = str(repeat_data['upper'])
+            variant_info['info_dict']['STR_PATHOLOGIC_MIN'] = str(repeat_data['upper'])
 
         click.echo(get_variant_line(variant_info, header_info))

--- a/stranger/utils.py
+++ b/stranger/utils.py
@@ -135,8 +135,8 @@ def get_repeat_info(variant_info, repeat_info):
         LOG.warning("No info for repeat id %s", repeat_id)
         return None
 
-    rep_lower = repeat_info[repeat_id].get('normal_max', 0)
-    rep_upper = repeat_info[repeat_id].get('pathologic_min', 0)
+    rep_lower = repeat_info[repeat_id].get('normal_max', -1)
+    rep_upper = repeat_info[repeat_id].get('pathologic_min', -1)
     for allele in alleles:
         if allele == '.':
             repeat_res = [0]

--- a/stranger/utils.py
+++ b/stranger/utils.py
@@ -125,7 +125,7 @@ def get_repeat_info(variant_info, repeat_info):
         repeat_info(dict)
 
     Returns:
-        info_string(str)
+        (dict): With repeat level, lower and upper limits
     """
     repeat_strings = []
     # There can be one or two alternatives
@@ -135,8 +135,8 @@ def get_repeat_info(variant_info, repeat_info):
         LOG.warning("No info for repeat id %s", repeat_id)
         return None
 
-    rep_lower = repeat_info[repeat_id]['normal_max']
-    rep_upper = repeat_info[repeat_id]['pathologic_min']
+    rep_lower = repeat_info[repeat_id].get('normal_max', 0)
+    rep_upper = repeat_info[repeat_id].get('pathologic_min', 0)
     for allele in alleles:
         if allele == '.':
             repeat_res = [0]
@@ -153,7 +153,7 @@ def get_repeat_info(variant_info, repeat_info):
         else:
             repeat_strings.append('full_mutation')
 
-    return ','.join(repeat_strings)
+    return dict(repeat_strings=','.join(repeat_strings), lower=rep_lower, upper=rep_upper)
 
 def get_info_dict(info_string):
     """Convert a info string to a dictionary


### PR DESCRIPTION
Adds the repeat number limits (max_normal and min_pathogenic) to each variant in the VCF.

We need this feature to be able to show these limits in Scout, to be able to quickly, for example, see if a pre-mutation is very close to normal or pathogenic.

Let me know if you have a better solution for this! I am also planning a pull request to Scout to show the limits in the STR list. I'll create an issue in the scout repo for that, so we can discuss it.