### PR TITLE
Fix #14: add a naive rank score.

### DIFF
--- a/stranger/cli.py
+++ b/stranger/cli.py
@@ -63,6 +63,10 @@ def cli(context, vcf, repeats_file, loglevel):
         {
             'id': 'STR_PATHOLOGIC_MIN', 'num': '1', 'type': 'Integer',
             'desc': 'Min number of repeats required to call as pathologic'
+        },
+        {
+            'id': 'RankScore', 'num': '1', 'type': 'Integer',
+            'desc': 'Min number of repeats required to call as pathologic'
         }
     ]
 
@@ -71,7 +75,7 @@ def cli(context, vcf, repeats_file, loglevel):
         header = '##INFO=<ID={0},Number={1},Type={2},Description="{3}">'.format(
             hdef.get('id'), hdef.get('num'), hdef.get('type'), hdef.get('desc'))
         stranger_headers.append(header)
-            
+
 
     if vcf.endswith('.gz'):
         LOG.info("Vcf is zipped")
@@ -100,6 +104,7 @@ def cli(context, vcf, repeats_file, loglevel):
         if repeat_data:
             variant_info['info_dict']['STR_STATUS'] = repeat_data['repeat_strings']
             variant_info['info_dict']['STR_NORMAL_MAX'] = str(repeat_data['lower'])
-            variant_info['info_dict']['STR_PATHOLOGIC_MIN'] = str(repeat_data['upper'])
+            variant_info['info_dict']['STR_PATHOLOGIC_MIN'] = str(repeat_data['upper']
+            variant_info['info_dict']['RankScore'] = str(repeat_data['rank_score'])
 
         click.echo(get_variant_line(variant_info, header_info))

--- a/stranger/cli.py
+++ b/stranger/cli.py
@@ -104,7 +104,7 @@ def cli(context, vcf, repeats_file, loglevel):
         if repeat_data:
             variant_info['info_dict']['STR_STATUS'] = repeat_data['repeat_strings']
             variant_info['info_dict']['STR_NORMAL_MAX'] = str(repeat_data['lower'])
-            variant_info['info_dict']['STR_PATHOLOGIC_MIN'] = str(repeat_data['upper']
+            variant_info['info_dict']['STR_PATHOLOGIC_MIN'] = str(repeat_data['upper'])
             variant_info['info_dict']['RankScore'] = str(repeat_data['rank_score'])
 
         click.echo(get_variant_line(variant_info, header_info))

--- a/stranger/constants.py
+++ b/stranger/constants.py
@@ -1,0 +1,5 @@
+RANK_SCORE = {
+        'normal' : 1,
+        'pre_mutation': 3,
+        'full_mutation': 5
+        }

--- a/stranger/resources/variant_catalog_references.json
+++ b/stranger/resources/variant_catalog_references.json
@@ -1,0 +1,303 @@
+[
+    {
+        "LocusId": "AFF2",
+        "LocusStructure": "(GCC)*",
+        "VariantType": "Repeat",
+        "Disease": "Fraxe",
+        "NormalMax": 40,
+        "PathologicMin": 200
+    },
+    {
+        "LocusId": "AR",
+        "LocusStructure": "(GCA)*",
+        "VariantType": "Repeat",
+        "Disease": "SBMA",
+        "NormalMax": 35,
+        "PathologicMin": 38
+    },
+    {
+        "LocusId": "ATN1",
+        "LocusStructure": "(CAG)*",
+        "VariantType": "Repeat",
+        "Disease": "DRPLA",
+        "NormalMax": 34,
+        "PathologicMin": 49
+    },
+    {
+        "LocusId": "ATXN10",
+        "LocusStructure": "(ATTCT)*",
+        "VariantType": "Repeat",
+        "Disease": "SCA10",
+        "NormalMax": 32,
+        "PathologicMin": 800
+    },
+    {
+        "LocusId": "ATXN1",
+        "LocusStructure": "(TGC)*",
+        "VariantType": "Repeat",
+        "Disease": "SCA1",
+        "NormalMax": 35,
+        "PathologicMin": 45
+    },
+    {
+        "LocusId": "ATXN2",
+        "LocusStructure": "(GCT)*",
+        "VariantType": "Repeat",
+        "Disease": "SCA2",
+        "NormalMax": 31,
+        "PathologicMin": 39
+    },
+    {
+        "LocusId": "ATXN3",
+        "LocusStructure": "(GCT)*",
+        "VariantType": "Repeat",
+        "Disease": "SCA3",
+        "NormalMax": 44,
+        "PathologicMin": 60
+    },
+    {
+        "LocusId": "PHOX2B",
+        "LocusStructure": "(GCN)*",
+        "VariantType": "Repeat",
+        "NormalMax": 60,
+        "PathologicMin": 72,
+        "Disease": "CCHS"
+    },
+    {
+        "LocusId": "ATXN7",
+        "LocusStructure": "(GCA)*(GCC)+",
+        ],
+        "VariantId": [
+            "ATXN7",
+            "ATXN7_GCC"
+        ],
+        "VariantType": [
+            "Repeat",
+            "Repeat"
+        ],
+        "Disease": "SCA7",
+        "NormalMax": 19,
+        "PathologicMin": 37,
+    },
+    {
+        "LocusId": "ATXN8OS",
+        "LocusStructure": "(CTA)*(CTG)*",
+        ],
+        "VariantId": [
+            "ATXN8OS_CTA",
+            "ATXN8OS"
+        ],
+        "VariantType": [
+            "Repeat",
+            "Repeat"
+        ],
+        "Disease": "SCA8",
+        "NormalMax": 50,
+        "PathologicMin": 80,
+    },
+    {
+        "LocusId": "C9ORF72",
+        "LocusStructure": "(GGCCCC)*",
+        ],
+        "VariantType": "RareRepeat",
+        "Disease": "FTDALS1",
+        "NormalMax": 25,
+        "PathologicMin": 40
+    },
+    {
+        "LocusId": "CACNA1A",
+        "LocusStructure": "(CTG)*",
+        "VariantType": "Repeat",
+        "Disease": "SCA6",
+        "NormalMax": 18,
+        "PathologicMin": 20
+    },
+    {
+        "LocusId": "CBL",
+        "LocusStructure": "(CGG)*",
+        "VariantType": "Repeat",
+        "Disease": "FRAX11B",
+        "NormalMax": 79,
+        "PathologicMin": 100
+    },
+    {
+        "LocusId": "CNBP",
+        "LocusStructure": "(CAGG)*(CAGA)*(CA)*",
+        ],
+        "VariantId": [
+            "CNBP",
+            "CNBP_CAGA",
+            "CNBP_CA"
+        ],
+        "VariantType": [
+            "Repeat",
+            "Repeat",
+            "Repeat"
+        ],
+        "Disease": "DM2",
+        "NormalMax": 30,
+        "PathologicMin": 75
+    },
+    {
+        "LocusId": "CSTB",
+        "LocusStructure": "(CGCGGGGCGGGG)*",
+        "VariantType": "Repeat",
+        "Disease": "EPM1",
+        "NormalMax": 3,
+        "PathologicMin": 30
+    },
+    {
+        "LocusId": "DIP2B",
+        "LocusStructure": "(GGC)*",
+        "VariantType": "Repeat",
+        "NormalMax": 24,
+        "PathologicMin": 270,
+        "Disease": "FRA12A"
+    },
+    {
+        "LocusId": "DMPK",
+        "LocusStructure": "(CAG)*",
+        "VariantType": "Repeat",
+        "Disease": "DM1",
+        "NormalMax": 37,
+        "PathologicMin": 50
+    },
+    {
+        "LocusId": "FMR1",
+        "LocusStructure": "(CGG)*",
+        ],
+        "VariantType": "RareRepeat",
+        "Disease": "FragileX",
+        "NormalMax": 65,
+        "PathologicMin": 200
+    },
+    {
+        "LocusId": "FXN",
+        "LocusStructure": "(A)*(GAA)*",
+        ],
+        "VariantId": [
+            "FXN_A",
+            "FXN"
+        ],
+        "VariantType": [
+            "Repeat",
+            "Repeat"
+        ],
+        "Disease": "FRDA",
+        "NormalMax": 35,
+        "PathologicMin": 51,
+    },
+    {
+        "LocusId": "HTT",
+        "LocusStructure": "(CAG)*CAACAG(CCG)*",
+        ],
+        "VariantId": [
+            "HTT",
+            "HTT_CCG"
+        ],
+        "VariantType": [
+            "Repeat",
+            "Repeat"
+        ],
+        "Disease": "Huntington",
+        "NormalMax": 36,
+        "PathologicMin": 37,
+    },
+    {
+        "LocusId": "JPH3",
+        "LocusStructure": "(CTG)*",
+        "VariantType": "Repeat",
+        "Disease": "HDL2",
+        "NormalMax": 28,
+        "PathologicMin": 40
+    },
+    {
+        "LocusId": "NOP56",
+        "LocusStructure": "(GGCCTG)*(CGCCTG)*",
+        ],
+        "VariantId": [
+            "NOP56",
+            "NOP56_CGCCTG"
+        ],
+        "VariantType": [
+            "Repeat",
+            "Repeat"
+        ],
+        "Disease": "SCA36",
+        "NormalMax": 14,
+        "PathologicMin": 650
+    },
+    {
+        "LocusId": "PPP2R2B",
+        "LocusStructure": "(GCT)*",
+        "VariantType": "Repeat",
+        "Disease": "SCA12",
+        "NormalMax": 35,
+        "PathologicMin": 49
+    },
+    {
+        "LocusId": "TBP",
+        "LocusStructure": "(GCA)*",
+        "VariantType": "Repeat",
+        "Disease": "SCA17",
+        "NormalMax": 44,
+        "PathologicMin": 49
+    },
+    {
+        "LocusId": "TCF4",
+        "LocusStructure": "(CAG)*",
+        "VariantType": "Repeat",
+        "NormalMax": 149,
+        "PathologicMin": 150,
+        "Disease": "FECD3"
+    },
+    {
+        "VariantType": "Repeat",
+        "LocusId": "NIPA1",
+        "LocusStructure": "(GCG)*",
+        "Disease": "ALS - susceptibility to",
+        "NormalMax": 8,
+        "PathologicMin": 10000,
+        "References": [{'PMID': 30342764}]
+    },
+    {
+        "LocusId": "NOTCH2NLC",
+        "LocusStructure": "(GGC)*",
+        "VariantType": "Repeat",
+        "Disease": "NIID",
+        "NormalMax": 30,
+        "PathologicMin": 71
+    },
+    {
+      "VariantType": "Repeat",
+      "LocusId": "GLS",
+      "LocusStructure": "(CAG)*CAC",
+      "Disease": "GDPAG",
+      "NormalMax": 20,
+      "PathologicMin": 90
+    },
+    {
+      "VariantType": "Repeat",
+      "LocusId": "RFC1",
+      "LocusStructure": "(AARRG)*",
+      "Disease": "CANVAS",
+      "NormalMax": 10,
+      "PathologicMin": 14
+    },
+    {
+      "VariantType": "Repeat",
+      "LocusId": "PABPN1",
+      "LocusStructure": "(GCG)*",
+      "Disease": "OPMD",
+      "NormalMax": 6,
+      "PathologicMin": 9
+    },
+    {
+      "VariantType": ["Repeat","Repeat"],
+      "LocusId": "POLG",
+      "VariantId": ["POLG_I", "POLG_II"],
+      "LocusStructure": "(CTG)*TTG(CTG)*",
+      "NormalMax": 15,
+      "PathologicMin": 10000,
+    }
+]

--- a/stranger/utils.py
+++ b/stranger/utils.py
@@ -4,7 +4,7 @@ import yaml
 
 from pprint import pprint as pp
 
-import stranger.constants
+from stranger.constants import RANK_SCORE
 
 NUM = re.compile(r'\d+')
 

--- a/stranger/utils.py
+++ b/stranger/utils.py
@@ -4,6 +4,8 @@ import yaml
 
 from pprint import pprint as pp
 
+import .constants
+
 NUM = re.compile(r'\d+')
 
 LOG = logging.getLogger(__name__)
@@ -137,6 +139,7 @@ def get_repeat_info(variant_info, repeat_info):
 
     rep_lower = repeat_info[repeat_id].get('normal_max', -1)
     rep_upper = repeat_info[repeat_id].get('pathologic_min', -1)
+    rank_score = 0
     for allele in alleles:
         if allele == '.':
             repeat_res = [0]
@@ -148,12 +151,18 @@ def get_repeat_info(variant_info, repeat_info):
         repeat_number = repeat_res[0]
         if repeat_number <= rep_lower:
             repeat_strings.append('normal')
+            if rank_score < RANK_SCORE['normal']
+                rank_score = RANK_SCORE['normal']
         elif repeat_number <= rep_upper:
             repeat_strings.append('pre_mutation')
+            if rank_score < RANK_SCORE['pre_mutation']
+                rank_score = RANK_SCORE['pre_mutation']
         else:
             repeat_strings.append('full_mutation')
+            rank_score = RANK_SCORE['full_mutation']
 
-    return dict(repeat_strings=','.join(repeat_strings), lower=rep_lower, upper=rep_upper)
+    return dict(repeat_strings=','.join(repeat_strings), lower=rep_lower,
+                upper=rep_upper, rank_score=rank_score)
 
 def get_info_dict(info_string):
     """Convert a info string to a dictionary

--- a/stranger/utils.py
+++ b/stranger/utils.py
@@ -4,7 +4,7 @@ import yaml
 
 from pprint import pprint as pp
 
-import .constants
+import stranger.constants
 
 NUM = re.compile(r'\d+')
 
@@ -151,11 +151,11 @@ def get_repeat_info(variant_info, repeat_info):
         repeat_number = repeat_res[0]
         if repeat_number <= rep_lower:
             repeat_strings.append('normal')
-            if rank_score < RANK_SCORE['normal']
+            if rank_score < RANK_SCORE['normal']:
                 rank_score = RANK_SCORE['normal']
         elif repeat_number <= rep_upper:
             repeat_strings.append('pre_mutation')
-            if rank_score < RANK_SCORE['pre_mutation']
+            if rank_score < RANK_SCORE['pre_mutation']:
                 rank_score = RANK_SCORE['pre_mutation']
         else:
             repeat_strings.append('full_mutation')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from stranger.resources import repeats_path
@@ -9,7 +10,6 @@ def vcf_path():
 @pytest.fixture()
 def vcf_zipped_path():
     return 'tests/fixtures/643594.clinical.str.vcf.gz'
-
 
 @pytest.fixture()
 def repeats_file_handle():


### PR DESCRIPTION
Trivially add a rank score matching mutation status (normal, pre- and full mutation). Useful e.g. to layout scout page - see e.g. https://github.com/Clinical-Genomics/scout/issues/1501.

- [x] simple function test with some ExHu 3.1.2 files.